### PR TITLE
feat: can check for equality between timespans by range and duration

### DIFF
--- a/src/timespan.ts
+++ b/src/timespan.ts
@@ -292,4 +292,23 @@ export class Timespan {
    * @returns The duration in years.
    */
   public toYears = (): number => this.toUnit('years');
+
+  /**
+   * Check if two timespans are equal.
+   * @param other - The other Timespan to compare with.
+   * @param compareBy - The method of comparison: 'range' for start and end dates, 'duration' for total duration.
+   * @returns True if the two timespans are equal, false otherwise.
+   */
+  public equals(
+    other: Timespan,
+    compareBy: 'range' | 'duration' = 'duration',
+  ): boolean {
+    if (compareBy === 'range') {
+      return (
+        this.start.getTime() === other.start.getTime() &&
+        this.end.getTime() === other.end.getTime()
+      );
+    }
+    return this.toMilliseconds() === other.toMilliseconds();
+  }
 }

--- a/test/timespan.test.ts
+++ b/test/timespan.test.ts
@@ -523,4 +523,36 @@ describe('Timespan', () => {
       expect(updatedDate.toYears()).toBe(expected);
     });
   });
+
+  describe('equals', () => {
+    it('should return true for equal timespans checked by duration', () => {
+      const timespan1 = new Timespan(start, end);
+      const timespan2 = new Timespan(start, end);
+      expect(timespan1.equals(timespan2)).toBe(true);
+    });
+
+    it('should return false for different timespans checked by duration', () => {
+      const timespan1 = new Timespan(start, end);
+      const timespan2 = new Timespan(
+        new Date('2022-01-01T06:24:00Z'),
+        new Date('2023-02-22T10:52:00Z'),
+      );
+      expect(timespan1.equals(timespan2)).toBe(false);
+    });
+
+    it('should return true for equal timespans checked by range', () => {
+      const timespan1 = new Timespan(start, end);
+      const timespan2 = new Timespan(start, end);
+      expect(timespan1.equals(timespan2, 'range')).toBe(true);
+    });
+
+    it('should return false for different timespans checked by range', () => {
+      const timespan1 = new Timespan(start, end);
+      const timespan2 = new Timespan(
+        new Date('2022-01-01T06:24:00Z'),
+        new Date('2023-02-22T10:52:00Z'),
+      );
+      expect(timespan1.equals(timespan2, 'range')).toBe(false);
+    });
+  });
 });


### PR DESCRIPTION
This change allows timespans to be compared for equality based on either the range (start date to end date) or the duration (total milliseconds).