### PR TITLE
feat: add static and instance compare to method

### DIFF
--- a/src/timespan.ts
+++ b/src/timespan.ts
@@ -238,6 +238,17 @@ export class Timespan {
   }
 
   /**
+   * Compare two timespans.
+   * @param ts1 - The first Timespan to compare.
+   * @param ts2 - The second Timespan to compare.
+   * @returns A negative number if ts1 is less than ts2, a positive number if
+   * ts1 is greater than ts2, and 0 if they are equal.
+   */
+  public static compareTo = (ts1: Timespan, ts2: Timespan): number => {
+    return ts1.compareTo(ts2);
+  };
+
+  /**
    * Convert the timespan to a TimeFrame object.
    * @returns The TimeFrame object representing the timespan.
    */
@@ -326,4 +337,21 @@ export class Timespan {
     }
     return this.toMilliseconds() === other.toMilliseconds();
   }
+
+  /**
+   * Compare this timespan to another timespan.
+   * @param other - The other Timespan to compare with.
+   * @returns A negative number if this timespan is less than the other,
+   */
+  public compareTo = (other: Timespan): number => {
+    const thisMillis = this.toMilliseconds();
+    const otherMillis = other.toMilliseconds();
+    if (thisMillis < otherMillis) {
+      return -1;
+    }
+    if (thisMillis > otherMillis) {
+      return 1;
+    }
+    return 0;
+  };
 }

--- a/test/timespan.test.ts
+++ b/test/timespan.test.ts
@@ -1,3 +1,5 @@
+// noinspection DuplicatedCode
+
 import { Timespan } from '../src';
 
 describe('Timespan', () => {
@@ -585,6 +587,54 @@ describe('Timespan', () => {
         new Date('2023-02-22T10:52:00Z'),
       );
       expect(Timespan.equals(timespan1, timespan2, 'range')).toBe(false);
+    });
+  });
+
+  describe('compareTo', () => {
+    it('should return 0 if the timespan is equal to the provided timespan', () => {
+      const timespan1 = new Timespan(start, end);
+      const timespan2 = new Timespan(start, end);
+      expect(timespan1.compareTo(timespan2)).toBe(0);
+    });
+    it('should return -1 if the timespan is less than to the provided timespan', () => {
+      const timespan1 = new Timespan(start, end);
+      const timespan2 = new Timespan(
+        new Date('2022-01-01T06:24:00Z'),
+        new Date('2023-02-22T10:52:00Z'),
+      );
+      expect(timespan1.compareTo(timespan2)).toBe(-1);
+    });
+    it('should return 1 if the timespan is greater than to the provided timespan', () => {
+      const timespan1 = new Timespan(start, end);
+      const timespan2 = new Timespan(
+        new Date('2022-01-01T06:24:00Z'),
+        new Date('2023-02-22T10:52:00Z'),
+      );
+      expect(timespan2.compareTo(timespan1)).toBe(1);
+    });
+  });
+
+  describe('static compareTo', () => {
+    it('should return 0 if the timespan is equal to the provided timespan', () => {
+      const timespan1 = new Timespan(start, end);
+      const timespan2 = new Timespan(start, end);
+      expect(Timespan.compareTo(timespan1, timespan2)).toBe(0);
+    });
+    it('should return -1 if the timespan is less than to the provided timespan', () => {
+      const timespan1 = new Timespan(start, end);
+      const timespan2 = new Timespan(
+        new Date('2022-01-01T06:24:00Z'),
+        new Date('2023-02-22T10:52:00Z'),
+      );
+      expect(Timespan.compareTo(timespan1, timespan2)).toBe(-1);
+    });
+    it('should return 1 if the timespan is greater than to the provided timespan', () => {
+      const timespan1 = new Timespan(start, end);
+      const timespan2 = new Timespan(
+        new Date('2022-01-01T06:24:00Z'),
+        new Date('2023-02-22T10:52:00Z'),
+      );
+      expect(Timespan.compareTo(timespan2, timespan1)).toBe(1);
     });
   });
 });


### PR DESCRIPTION
This feature adds the ability to compare one timespan to another. It returns the standard output of 1, 0, -1 that you would expect from a compare function. This should allow sorting timespans. This does only compare based on duration. This means that you aren't comparing the range of the timespan (start to end time). Instead, you are only comparing the total time of the timespan. This made the most sense. 